### PR TITLE
Removed 'num_links' parameter from pagination init array

### DIFF
--- a/third_party/better_pagination/ext.better_pagination.php
+++ b/third_party/better_pagination/ext.better_pagination.php
@@ -315,7 +315,6 @@ class Better_pagination_ext {
             'cur_page'      => $this->offset,
             'total_rows'    => $total_results,
             'prefix'        => '', // Remove that stupid P
-            'num_links'     => 100,
             'uri_segment'   => 0,
             'query_string_segment' => $this->page_var,
             'page_query_string' => TRUE


### PR DESCRIPTION
It was overriding the default number of page links generated (2) and overriding the value of [page_padding](https://ellislab.com/expressionengine/user-guide/templates/pagination.html#page-padding). Tested on EE 2.9.2.